### PR TITLE
Add support for some common GLSL extensions

### DIFF
--- a/Syntaxes/GLSL.tmLanguage
+++ b/Syntaxes/GLSL.tmLanguage
@@ -6,6 +6,10 @@
 	<array>
 		<string>vs</string>
 		<string>fs</string>
+		<string>vsh</string>
+		<string>fsh</string>
+		<string>vshader</string>
+		<string>fshader</string>
 		<string>vert</string>
 		<string>frag</string>
 	</array>


### PR DESCRIPTION
I find that these extensions pop up pretty frequently. `.vsh` and `.fsh` are the defaults supported by Xcode.
