### PR TITLE
New extensions & update installation instruction

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -4,7 +4,16 @@ The OpenGL Shading Language TextMate Bundle
 
 <h2>Installation</h2>
 
+<h3>TextMate 1</h3>
+
 <pre>
 cd ~/Library/Application\ Support/TextMate/Bundles
+git clone git://github.com/polym0rph/GLSL.tmbundle.git GLSL.tmbundle
+</pre>
+
+<h3>TextMate 2</h3>
+
+<pre>
+cd ~/Library/Application\ Support/Avian/Bundles
 git clone git://github.com/polym0rph/GLSL.tmbundle.git GLSL.tmbundle
 </pre>

--- a/Syntaxes/GLSL.tmLanguage
+++ b/Syntaxes/GLSL.tmLanguage
@@ -16,6 +16,9 @@
 		<string>vert</string>
 		<string>frag</string>
 		<string>geom</string>
+		<string>f.glsl</string>
+		<string>v.glsl</string>
+		<string>g.glsl</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>/\*\*|\{\s*$</string>

--- a/Syntaxes/GLSL.tmLanguage
+++ b/Syntaxes/GLSL.tmLanguage
@@ -6,12 +6,16 @@
 	<array>
 		<string>vs</string>
 		<string>fs</string>
+		<string>gs</string>
 		<string>vsh</string>
 		<string>fsh</string>
+		<string>gsh</string>
 		<string>vshader</string>
 		<string>fshader</string>
+		<string>gshader</string>
 		<string>vert</string>
 		<string>frag</string>
+		<string>geom</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>/\*\*|\{\s*$</string>


### PR DESCRIPTION
I usually name my shaders xxxx.v.glsl, xxxx.f.glsl and xxxx.g.glsl so I added support for those extensions. I took the opportunity to also add extension for geometry shaders.

I also updated the installation instruction to work with TextMate 2.
